### PR TITLE
Hotfix

### DIFF
--- a/src/groupsig/bbs04/signature.c
+++ b/src/groupsig/bbs04/signature.c
@@ -422,7 +422,7 @@ char* bbs04_signature_to_string(groupsig_signature_t *sig) {
 
   bytes = NULL;
   if(bbs04_signature_export(&bytes, &size, sig) == IERROR) return NULL;
-  str = base64_encode(bytes, size);
+  str = base64_encode(bytes, size, 0);
   mem_free(bytes); bytes = NULL;
 
   return str;

--- a/src/groupsig/gl19/blindsig.c
+++ b/src/groupsig/gl19/blindsig.c
@@ -177,7 +177,7 @@ char* gl19_blindsig_to_string(groupsig_blindsig_t *sig) {
 
   bytes = NULL;
   if(gl19_blindsig_export(&bytes, &size, sig) == IERROR) return NULL;
-  str = base64_encode(bytes, size);
+  str = base64_encode(bytes, size, 0);
   mem_free(bytes); bytes = NULL;  
   
   return str;

--- a/src/groupsig/gl19/signature.c
+++ b/src/groupsig/gl19/signature.c
@@ -186,7 +186,7 @@ char* gl19_signature_to_string(groupsig_signature_t *sig) {
 
   bytes = NULL;
   if(gl19_signature_export(&bytes, &size, sig) == IERROR) return NULL;
-  str = base64_encode(bytes, size);
+  str = base64_encode(bytes, size, 0);
   mem_free(bytes); bytes = NULL;
 
   return str;

--- a/src/msg/message.c
+++ b/src/msg/message.c
@@ -287,7 +287,7 @@ char* message_to_base64(message_t *msg) {
     return NULL;
   }
 
-  return base64_encode(msg->bytes, msg->length);
+  return base64_encode(msg->bytes, msg->length, 0);
 
 }
 

--- a/src/shim/base64.h
+++ b/src/shim/base64.h
@@ -24,15 +24,17 @@
 #include "types.h"
 
 /** 
- * @fn char* base64_encode(const byte_t *in, uint64_t length)
+ * @fn char* base64_encode(const byte_t *in, uint64_t length, uint8_t nl)
  * @brief Base64-encodes the specified byte array.
  *
  * @param[in] in The byte array to encode.
  * @param[in] length The number of bytes in <i>in</i>.
+ * @param[in] nl If 0, no line feeds will be added every 72 chars nor
+ *  at the end of the resulting string. Else, they will.
  * 
  * @return A pointer to the resulting Base64 string, or NULL if error.
  */
-char* base64_encode(const byte_t *in, uint64_t length);
+char* base64_encode(const byte_t *in, uint64_t length, uint8_t nl);
 
 /** 
  * @fn byte_t* base64_decode(const char *in, uint64_t *length_dec)

--- a/src/shim/pbc_ext.c
+++ b/src/shim/pbc_ext.c
@@ -1604,7 +1604,7 @@ char* pbcext_element_Fr_to_b64(pbcext_element_Fr_t *e) {
     return NULL;
   }
   
-  s = base64_encode(bytes, len);
+  s = base64_encode(bytes, len, 0);
 
   /* We do not want the trailing '\n' */
   if (s[strlen(s)-1] == '\n') s[strlen(s)-1] = 0;
@@ -1632,7 +1632,7 @@ char* pbcext_element_Fp_to_b64(pbcext_element_Fp_t *e) {
     return NULL;
   }
   
-  s = base64_encode(bytes, len);
+  s = base64_encode(bytes, len, 0);
 
   /* We do not want the trailing '\n' */
   if (s[strlen(s)-1] == '\n') s[strlen(s)-1] = 0;
@@ -1660,7 +1660,7 @@ char* pbcext_element_G1_to_b64(pbcext_element_G1_t *e) {
     return NULL;
   }
   
-  s = base64_encode(bytes, len);
+  s = base64_encode(bytes, len, 0);
 
   /* We do not want the trailing '\n' */
   if (s[strlen(s)-1] == '\n') s[strlen(s)-1] = 0;
@@ -1688,7 +1688,7 @@ char* pbcext_element_G2_to_b64(pbcext_element_G2_t *e) {
     return NULL;
   }
   
-  s = base64_encode(bytes, len);
+  s = base64_encode(bytes, len, 0);
 
   /* We do not want the trailing '\n' */
   if (s[strlen(s)-1] == '\n') s[strlen(s)-1] = 0;
@@ -1716,7 +1716,7 @@ char* pbcext_element_GT_to_b64(pbcext_element_GT_t *e) {
     return NULL;
   }
   
-  s = base64_encode(bytes, len);
+  s = base64_encode(bytes, len, 0);
 
   /* We do not want the trailing '\n' */
   if (s[strlen(s)-1] == '\n') s[strlen(s)-1] = 0;

--- a/src/wrappers/nodejs/jsgroupsig/cmake_modules/libgroupsig.cmake
+++ b/src/wrappers/nodejs/jsgroupsig/cmake_modules/libgroupsig.cmake
@@ -2,7 +2,7 @@ include(ExternalProject)
 set(EXTERNAL_INSTALL_LOCATION ${CMAKE_BINARY_DIR}/external)
 
 ExternalProject_Add(libgroupsig
-  GIT_REPOSITORY https://github.com/IBM/libgroupsig.git
+  GIT_REPOSITORY https://github.com/jdv-ibm/libgroupsig.git
   CMAKE_ARGS
   -DCMAKE_INSTALL_PREFIX=${EXTERNAL_INSTALL_LOCATION}
   -DCMAKE_INSTALL_RPATH=${CMAKE_BINARY_DIR}/libgroupsig-prefix/src/libgroupsig-build/external/lib

--- a/src/wrappers/nodejs/jsgroupsig/src/base64.c
+++ b/src/wrappers/nodejs/jsgroupsig/src/base64.c
@@ -1,3 +1,16 @@
+/** 
+ * The following is based on Jouni Malinen's code for base64 encoding, 
+ * Original copyright license is copied verbatim.
+ **/
+
+/*
+ * Base64 encoding/decoding (RFC1341)
+ * Copyright (c) 2005-2011, Jouni Malinen <j@w1.fi>
+ *
+ * This software may be distributed under the terms of the BSD license.
+ * See README for more details.
+ */
+
 #include <stdlib.h>
 #include <string.h>
 
@@ -10,12 +23,13 @@ static const unsigned char base64_table[65] =
  * base64_encode - Base64 encode
  * @src: Data to be encoded. Must be a 0-ended string.
  * @len: Length of the data to be encoded
+ * @nl: If 0, no '\n' chars will be added each 72 chars nor at the end.
  *
  * Caller is responsible for freeing the returned buffer. Returned buffer is
  * nul terminated to make it easier to use as a C string. The nul terminator is
  * not included in out_len.
  */
-char * base64_encode(const unsigned char *src, uint64_t len) {
+char * base64_encode(const unsigned char *src, uint64_t len, uint8_t nl) {
 
   char *out, *pos;
   const unsigned char *end, *in;
@@ -26,7 +40,7 @@ char * base64_encode(const unsigned char *src, uint64_t len) {
   }
 
   olen = len * 4 / 3 + 4; /* 3-byte blocks to 4-byte */
-  olen += olen / 72; /* line feeds */
+  if(nl) olen += olen / 72; /* line feeds */
   olen++; /* nul termination */
   if (olen < len)
     return NULL; /* integer overflow */
@@ -45,7 +59,7 @@ char * base64_encode(const unsigned char *src, uint64_t len) {
     *pos++ = base64_table[in[2] & 0x3f];
     in += 3;
     line_len += 4;
-    if (line_len >= 72) {
+    if (line_len >= 72 && nl) {
       *pos++ = '\n';
       line_len = 0;
     }
@@ -65,7 +79,7 @@ char * base64_encode(const unsigned char *src, uint64_t len) {
     line_len += 4;
   }
 
-  if (line_len)
+  if (line_len && nl)
     *pos++ = '\n';
 
   *pos = '\0';

--- a/src/wrappers/nodejs/jsgroupsig/src/base64.h
+++ b/src/wrappers/nodejs/jsgroupsig/src/base64.h
@@ -31,7 +31,7 @@
  * 
  * @return A pointer to the resulting Base64 string, or NULL if error.
  */
-char* base64_encode(const unsigned char *in, uint64_t length);
+char* base64_encode(const unsigned char *in, uint64_t length, uint8_t nl);
 
 /** 
  * @fn unsigned char* base64_decode(const char *in, uint64_t *length_dec)

--- a/src/wrappers/nodejs/jsgroupsig/src/jsgroupsig.c
+++ b/src/wrappers/nodejs/jsgroupsig/src/jsgroupsig.c
@@ -1557,7 +1557,7 @@ napi_value gs_grp_key_export
   status = groupsig_grp_key_export(&bytes, (uint32_t *) &size, key);
   assert (status == napi_ok);
 
-  if(!(str = base64_encode(bytes, size))) {
+  if(!(str = base64_encode(bytes, size, 0))) {
     napi_throw_type_error(env, NULL, "Internal error");	       
     return NULL;
   }
@@ -1894,7 +1894,7 @@ napi_value gs_mgr_key_export
   status = groupsig_mgr_key_export(&bytes, (uint32_t *) &size, key);
   assert (status == napi_ok);
 
-  if(!(str = base64_encode(bytes, size))) {
+  if(!(str = base64_encode(bytes, size, 0))) {
     napi_throw_type_error(env, NULL, "Internal error");	       
     return NULL;
   }
@@ -2231,7 +2231,7 @@ napi_value gs_mem_key_export
   status = groupsig_mem_key_export(&bytes, (uint32_t *) &size, key);
   assert (status == napi_ok);   
 
-  if(!(str = base64_encode(bytes, size))) {
+  if(!(str = base64_encode(bytes, size, 0))) {
     napi_throw_type_error(env, NULL, "Internal error");	       
     return NULL;
   }
@@ -2608,7 +2608,7 @@ napi_value gs_bld_key_export
   status = groupsig_bld_key_export(&bytes, (uint32_t *) &size, key);
   assert (status == napi_ok);   
 
-  if(!(str = base64_encode(bytes, size))) {
+  if(!(str = base64_encode(bytes, size, 0))) {
     napi_throw_type_error(env, NULL, "Internal error");	       
     return NULL;
   }
@@ -2654,7 +2654,7 @@ napi_value gs_bld_key_export_pub
   status = groupsig_bld_key_export_pub(&bytes, (uint32_t *) &size, key);
   assert (status == napi_ok);   
 
-  if(!(str = base64_encode(bytes, size))) {
+  if(!(str = base64_encode(bytes, size, 0))) {
     napi_throw_type_error(env, NULL, "Internal error");	       
     return NULL;
   }
@@ -2992,7 +2992,7 @@ napi_value gs_signature_export
   status = groupsig_signature_export(&bytes, (uint32_t *) &size, sig);
   assert (status == napi_ok);   
 
-  if(!(str = base64_encode(bytes, size))) {
+  if(!(str = base64_encode(bytes, size, 0))) {
     napi_throw_type_error(env, NULL, "Internal error");	       
     return NULL;
   }
@@ -3330,7 +3330,7 @@ napi_value gs_blindsig_export
   status = groupsig_blindsig_export(&bytes, (uint32_t *) &size, sig);
   assert (status == napi_ok);   
 
-  if(!(str = base64_encode(bytes, size))) {
+  if(!(str = base64_encode(bytes, size, 0))) {
     napi_throw_type_error(env, NULL, "Internal error");	       
     return NULL;
   }

--- a/src/wrappers/python/pygroupsig/bldkey.py
+++ b/src/wrappers/python/pygroupsig/bldkey.py
@@ -13,6 +13,7 @@ def bldkey_export(bldkey):
     if lib.groupsig_bld_key_export(bkey, size, bldkey) == constants.IERROR:
         raise Exception('Error exporting blinding key.')
     b64key = base64.b64encode(ffi.buffer(bkey[0],size[0]))
+    b64key = b64key.decode('utf-8').replace('\n', '')
 #    lib.free(bkey[0])
     return b64key
 
@@ -24,6 +25,7 @@ def bldkey_export_pub(bldkey):
     if lib.groupsig_bld_key_export_pub(bkey, size, bldkey) == constants.IERROR:
         raise Exception('Error exporting blinding public key.')
     b64key = base64.b64encode(ffi.buffer(bkey[0],size[0]))
+    b64key = b64key.decode('utf-8').replace('\n', '')    
 #    lib.free(bkey[0])
     return b64key
     

--- a/src/wrappers/python/pygroupsig/blindsig.py
+++ b/src/wrappers/python/pygroupsig/blindsig.py
@@ -10,7 +10,8 @@ def blindsig_export(sig):
     if lib.groupsig_blindsig_export(bsig, size, sig) == constants.IERROR:
         raise Exception('Error exporting blindsig.')
     b64sig = base64.b64encode(ffi.buffer(bsig[0],size[0]))
-#    lib.free(bsig[0])
+    b64sig = b64sig.decode('utf-8').replace('\n', '')
+    #    lib.free(bsig[0])
     return b64sig
 
 def blindsig_import(code, b64sig):

--- a/src/wrappers/python/pygroupsig/grpkey.py
+++ b/src/wrappers/python/pygroupsig/grpkey.py
@@ -9,7 +9,8 @@ def grpkey_export(grpkey):
     size = ffi.new("uint32_t *")
     if lib.groupsig_grp_key_export(bkey, size, grpkey) == constants.IERROR:
         raise Exception('Error exporting group key.')
-    b64 = base64.b64encode(ffi.buffer(bkey[0],size[0]))    
+    b64 = base64.b64encode(ffi.buffer(bkey[0],size[0]))
+    b64 = b64.decode('utf-8').replace('\n', '')
     #    lib.free(bkey[0])
     return b64
 

--- a/src/wrappers/python/pygroupsig/memkey.py
+++ b/src/wrappers/python/pygroupsig/memkey.py
@@ -10,6 +10,7 @@ def memkey_export(memkey):
     if lib.groupsig_mem_key_export(bkey, size, memkey) == constants.IERROR:
         raise Exception('Error exporting member key.')
     b64key = base64.b64encode(ffi.buffer(bkey[0],size[0]))
+    b64key = b64key.decode('utf-8').replace('\n', '')    
     #    lib.free(bkey)
     return b64key    
 

--- a/src/wrappers/python/pygroupsig/mgrkey.py
+++ b/src/wrappers/python/pygroupsig/mgrkey.py
@@ -10,6 +10,7 @@ def mgrkey_export(mgrkey):
     if lib.groupsig_mgr_key_export(bkey, size, mgrkey) == constants.IERROR:
         raise Exception('Error exporting manager key.')
     b64key = base64.b64encode(ffi.buffer(bkey[0],size[0]))
+    b64key = b64key.decode('utf-8').replace('\n', '')    
 #    lib.free(bkey[0])
     return b64key
 

--- a/src/wrappers/python/pygroupsig/signature.py
+++ b/src/wrappers/python/pygroupsig/signature.py
@@ -10,7 +10,8 @@ def signature_export(sig):
     if lib.groupsig_signature_export(bsig, size, sig) == constants.IERROR:
         raise Exception('Error exporting signature.')
     b64sig = base64.b64encode(ffi.buffer(bsig[0],size[0]))
-#    lib.free(bsig[0])
+    b64sig = b64sig.decode('utf-8').replace('\n', '')
+    #    lib.free(bsig[0])
     return b64sig    
 
 def signature_import(code, b64sig):


### PR DESCRIPTION
The NodeJS wrapper (through the sample test server) and the Python wrapper were failing to integrate due to the jsgroupsig '\n' characters being added every 76 chars in Base64 encodings.